### PR TITLE
Extra test for converting elements within arrays

### DIFF
--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -207,6 +207,21 @@ describe LogStash::Filters::Mutate do
     end
   end
 
+  describe "convert should work within arrays" do
+    config <<-CONFIG
+      filter {
+        mutate {
+          convert => [ "[foo][0]", "integer" ]
+        }
+      }
+    CONFIG
+
+    sample({ "foo" => ["100", "200"] }) do
+      insist { subject["[foo][0]"] } == 100
+      insist { subject["[foo][0]"] }.is_a?(Fixnum)
+    end
+  end
+
   #LOGSTASH-1529
   describe "gsub on a String with dynamic fields (%{}) in pattern" do
     config '


### PR DESCRIPTION
Previously: "mutate { convert => [ \"[a][0]\", \"float\" ]  } }" would
throw an exception because the '0' element accessor was being treated
as a String by Logstash.

Now: A fix in Logstash should fix this, and this test is here to verify
that.

related issue: https://github.com/elasticsearch/logstash/issues/1401
