### PR TITLE
prevent upercase/downcase for not String object

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -332,7 +332,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   def uppercase(event)
     @uppercase.each do |field|
       if event[field].is_a?(Array)
-        event[field].each { |v| v.upcase! }
+        event[field].each { |v|
+           v.upcase! if v.is_a?(String) 
+         }
       elsif event[field].is_a?(String)
         event[field].upcase!
       else
@@ -346,7 +348,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   def lowercase(event)
     @lowercase.each do |field|
       if event[field].is_a?(Array)
-        event[field].each { |v| v.downcase! }
+        event[field].each { |v| 
+          v.downcase! if v.is_a?(String)
+        }
       elsif event[field].is_a?(String)
         event[field].downcase!
       else


### PR DESCRIPTION
I'm hitting this bug:

{:timestamp=>"2014-11-15T19:52:45.395000+0000", :message=>"Exception in filterworker", "exception"=>#>, "backtrace"=>["/opt/logstash/lib/logstash/filters/mutate.rb:338:in lowercase'", "org/jruby/RubyArray.java:1613:ineach'", "/opt/logstash/lib/logstash/filters/mutate.rb:338:in lowercase'", "org/jruby/RubyArray.java:1613:ineach'", "/opt/logstash/lib/logstash/filters/mutate.rb:336:in lowercase'", "/opt/logstash/lib/logstash/filters/mutate.rb:212:infilter'", "(eval):391:in initialize'", "org/jruby/RubyProc.java:271:incall'", "/opt/logstash/lib/logstash/pipeline.rb:262:in filter'", "/opt/logstash/lib/logstash/pipeline.rb:203:infilterworker'", "/opt/logstash/lib/logstash/pipeline.rb:143:in `start_filters'"], :level=>:error}

in logstash 1.4.2. 
root@logstash-s1:/var/log/logstash# zgrep -c "Exception in filterworker" logstash.log..gz
logstash.log.1.gz:213
logstash.log.2.gz:325
logstash.log.3.gz:278
logstash.log.4.gz:32
logstash.log.5.gz:118
logstash.log.6.gz:1
root@logstash-s2:/var/log/logstash# zgrep -c "Exception in filterworker" logstash.log..gz
logstash.log.1.gz:220
logstash.log.2.gz:267
logstash.log.3.gz:320
logstash.log.4.gz:53
logstash.log.5.gz:29

When this issue appears logstash freeze and not process new logs. 
This simple fix resolved this issue.

Ported from logstash 1.4.2 PR https://github.com/elasticsearch/logstash/pull/2091