### PR TITLE
Feature: select - only keep the selected fields

### DIFF
--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-patterns-core'
   s.add_runtime_dependency 'logstash-filter-grok'
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Allow a user to only keep the specified fields.

This is a nice feature for when an input like IMAP is used where a number of (sometimes) useless fields are added, and you don't want to list all the fields to remove. Specifically since you're not sure what those extra fields will always be.

Tests included.