### PR TITLE
added _mutateparsefailure to tags before every debug

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -260,6 +260,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       if original.nil?
         next
       elsif original.is_a?(Hash)
+        event.tag("_mutateparsefailure")
         @logger.debug("I don't know how to type convert a hash, skipping",
                       :field => field, :value => original)
         next
@@ -307,6 +308,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
         end
       else
         if not event[field].is_a?(String)
+          event.tag("_mutateparsefailure")
           @logger.debug("gsub mutation is only applicable for Strings, " +
                         "skipping", :field => field, :value => event[field])
           next
@@ -334,6 +336,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       elsif event[field].is_a?(String)
         event[field].upcase!
       else
+        event.tag("_mutateparsefailure")
         @logger.debug("Can't uppercase something that isn't a string",
                       :field => field, :value => event[field])
       end
@@ -348,6 +351,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       elsif event[field].is_a?(String)
         event[field].downcase!
       else
+        event.tag("_mutateparsefailure")
         @logger.debug("Can't lowercase something that isn't a string",
                       :field => field, :value => event[field])
       end
@@ -360,6 +364,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       if event[field].is_a?(String)
         event[field] = event[field].split(separator)
       else
+        event.tag("_mutateparsefailure")
         @logger.debug("Can't split something that isn't a string",
                       :field => field, :value => event[field])
       end


### PR DESCRIPTION
My configs currently expect certain fields to have certain values.  Unfortunately some of the processes I use to generate certain logs to not have atomic write operations at least per line.  This means that lines will occasionally be read before a process finishes writing it.  Mutate will then throw null values for the incomplete fields, which is fine except that the only way I can test this is to look for nil values on specific fields.  This is not ideal, as it makes this test hard to implement (ruby code) and specific to the data I am working with.

A _mutateparsefailure tag would be the best general purpose solution to this type of problem, as _[filter]parsefailure tags are the fairly standardized way of handling bad data.