### PR TITLE
Allow for dynamic field names in rename and remove

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -62,11 +62,11 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   # If the field is a hash, no action will be taken.
   #
   # If the conversion type is `boolean`, the acceptable values are:
-  # 
+  #
   # * **True:** `true`, `t`, `yes`, `y`, and `1`
   # * **False:** `false`, `f`, `no`, `n`, and `0`
   #
-  # If a value other than these is provided, it will pass straight through 
+  # If a value other than these is provided, it will pass straight through
   # and log a warning message.
   #
   # Valid conversion targets are: integer, float, string, and boolean.
@@ -226,16 +226,17 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
 
   private
   def remove(event)
-    # TODO(sissel): use event.sprintf on the field names?
     @remove.each do |field|
+      field = event.sprintf(field)
       event.remove(field)
     end
   end # def remove
 
   private
   def rename(event)
-    # TODO(sissel): use event.sprintf on the field names?
     @rename.each do |old, new|
+      old = event.sprintf(old)
+      new = event.sprintf(new)
       next unless event.include?(old)
       event[new] = event.remove(old)
     end

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -108,6 +108,22 @@ describe LogStash::Filters::Mutate do
     end
   end
 
+  describe "remove with dynamic fields (%{})" do
+    config '
+      filter {
+        mutate {
+          remove => [ "field_%{x}" ]
+        }
+      }'
+
+    sample(
+      "x" => "one",
+      "field_one" => "value"
+    ) do
+      reject { subject }.include?("field_one")
+    end
+  end
+
   describe "convert one field to string" do
     config '
       filter {
@@ -255,6 +271,36 @@ describe LogStash::Filters::Mutate do
     sample "whatever" do
       reject { subject }.include?("nosuchfield")
       reject { subject }.include?("hello")
+    end
+  end
+
+  describe "rename with dynamic origin field (%{})" do
+    config <<-CONFIG
+      filter {
+        mutate {
+          rename => [ "field_%{x}", "destination" ]
+        }
+      }
+    CONFIG
+
+    sample("field_one" => "value", "x" => "one") do
+      reject { subject }.include?("field_one")
+      insist { subject }.include?("destination")
+    end
+  end
+
+  describe "rename with dynamic destination field (%{})" do
+    config <<-CONFIG
+      filter {
+        mutate {
+          rename => [ "origin", "field_%{x}" ]
+        }
+      }
+    CONFIG
+
+    sample("field_one" => "value", "x" => "one") do
+      reject { subject }.include?("origin")
+      insist { subject }.include?("field_one")
     end
   end
 


### PR DESCRIPTION
Apply sprintf to event names for the `remove` and `rename` mutations.