### PR TITLE
Fix for Issue 44 - Lowercase fails when text is already all lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+ - Fix for uppercase and lowercase fail when value is already desired case
+ - Modify tests to prove bug and verify fix.
+
 ## 1.0.1
  - Fix for uppercase and lowercase malfunction
  - Specific test to prove bug and fix.

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -357,7 +357,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
           @logger.debug("Can't uppercase something that isn't a string",
                         :field => field, :value => original)
           original
-      end
+        end
     end
   end # def uppercase
 

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '1.0.1'
+  s.version         = '1.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The mutate filter allows you to perform general mutations on fields. You can rename, remove, replace, and modify fields in your events."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/integration/multi_stage_spec.rb
+++ b/spec/filters/integration/multi_stage_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::Filters::Mutate do
 
   describe 'MUTATE-33: multi stage with json, grok and mutate, Case mutation' do
     let(:event) do
-      "{\"message\":\"hello WORLD\",\"examplefield\":\"PPQQRRSS\"}"
+      "{\"message\":\"hello WORLD\",\"lower1\":\"PPQQRRSS\",\"lower2\":\"pppqqq\"}"
     end
 
     let(:config) do
@@ -46,7 +46,7 @@ filter {
         singles => true
     }
     mutate {
-      lowercase => [ "bar", "examplefield" ]
+      lowercase => [ "bar", "lower1", "lower2" ]
     }
 }
 CONFIG
@@ -57,9 +57,14 @@ CONFIG
       expect(result["bar"]).to eq('world')
     end
 
-    it 'change case of the target, examplefield value is lowercase' do
+    it 'change case of the target, lower1 value is lowercase' do
       result = results.first
-      expect(result["examplefield"]).to eq("ppqqrrss")
+      expect(result["lower1"]).to eq("ppqqrrss")
+    end
+
+    it 'change case of the target, lower2 value is lowercase' do
+      result = results.first
+      expect(result["lower2"]).to eq("pppqqq")
     end
 
   end

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -104,14 +104,14 @@ describe LogStash::Filters::Mutate do
     CONFIG
 
     event = {
-      "lowerme" => [ "АБВГД\0MMM", "こにちわ", "XyZółć"],
-      "upperme" => [ "аБвгд\0mmm", "こにちわ", "xYzółć"],
+      "lowerme" => [ "АБВГД\0MMM", "こにちわ", "XyZółć", "NÎcË GÛŸ"],
+      "upperme" => [ "аБвгд\0mmm", "こにちわ", "xYzółć", "Nîcë gûÿ"],
     }
 
     sample event do
       # ATM, only the ASCII characters will case change
-      expect(subject["lowerme"]).to eq [ "АБВГД\0mmm", "こにちわ", "xyzółć"]
-      expect(subject["upperme"]).to eq [ "аБвгд\0MMM", "こにちわ", "XYZółć"]
+      expect(subject["lowerme"]).to eq [ "АБВГД\0mmm", "こにちわ", "xyzółć", "nÎcË gÛŸ"]
+      expect(subject["upperme"]).to eq [ "аБвгд\0MMM", "こにちわ", "XYZółć", "NîCë Gûÿ"]
     end
   end
 

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -45,8 +45,8 @@ describe LogStash::Filters::Mutate do
     config <<-CONFIG
       filter {
         mutate {
-          lowercase => "lowerme"
-          uppercase => "upperme"
+          lowercase => ["lowerme","Lowerme", "lowerMe"]
+          uppercase => ["upperme", "Upperme", "upperMe"]
           convert => [ "intme", "integer", "floatme", "float" ]
           rename => [ "rename1", "rename2" ]
           replace => [ "replaceme", "hello world" ]
@@ -59,8 +59,12 @@ describe LogStash::Filters::Mutate do
     CONFIG
 
     event = {
-      "lowerme" => [ "ExAmPlE" ],
-      "upperme" => [ "ExAmPlE" ],
+      "lowerme" => "example",
+      "upperme" => "EXAMPLE",
+      "Lowerme" => "ExAmPlE",
+      "Upperme" => "ExAmPlE",
+      "lowerMe" => [ "ExAmPlE", "example" ],
+      "upperMe" => [ "ExAmPlE", "EXAMPLE" ],
       "intme" => [ "1234", "7890.4", "7.9" ],
       "floatme" => [ "1234.455" ],
       "rename1" => [ "hello world" ],
@@ -70,8 +74,12 @@ describe LogStash::Filters::Mutate do
     }
 
     sample event do
-      expect(subject["lowerme"]).to eq ['example']
-      expect(subject["upperme"]).to eq ['EXAMPLE']
+      expect(subject["lowerme"]).to eq 'example'
+      expect(subject["upperme"]).to eq 'EXAMPLE'
+      expect(subject["Lowerme"]).to eq 'example'
+      expect(subject["Upperme"]).to eq 'EXAMPLE'
+      expect(subject["lowerMe"]).to eq ['example', 'example']
+      expect(subject["upperMe"]).to eq ['EXAMPLE', 'EXAMPLE']
       expect(subject["intme"] ).to eq [1234, 7890, 7]
       expect(subject["floatme"]).to eq [1234.455]
       expect(subject).not_to include("rename1")


### PR DESCRIPTION
This bug was introduced by PR #43
Existing test coverage insufficient
(J)Ruby returns nil if the value is already in desired case for ```upcase!``` and ```downcase!```
This nil value was stored back in the Event
(J)Ruby returns the updated original object when a modify happens

closes #44