### PR TITLE
Prevent downcase/upcase for non string object (add test and improve the PR)

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -350,7 +350,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
         when Array
           # can't map upcase! as it replaces an already upcase value with nil
           # ["ABCDEF"].map(&:upcase!) => [nil]
-          original.map(&:upcase)
+          original.map do |elem|
+           (elem.is_a?(String) ? elem.upcase : elem)
+          end
         when String
           # nil means no change was made to the String
           original.upcase! || original
@@ -369,7 +371,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       original = event[field]
       event[field] = case original
         when Array
-          original.map(&:downcase)
+          original.map! do |elem|
+            (elem.is_a?(String) ? elem.downcase : elem)
+          end
         when String
           original.downcase! || original
         else

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -36,6 +36,7 @@ describe LogStash::Filters::Mutate do
     end
 
     it "should convert only string elements" do
+      subject.filter(event)
       expect(event["array_of"]).to eq(["A", 2, "C"])
     end
   end
@@ -48,11 +49,12 @@ describe LogStash::Filters::Mutate do
 
     let(:attrs) { { "array_of" => ["a", 2, "C"] } }
 
-    it "should uppercase all string elements" do
+    it "should lowercase all string elements" do
       expect { subject.filter(event) }.not_to raise_error
     end
 
     it "should convert only string elements" do
+      subject.filter(event)
       expect(event["array_of"]).to eq(["a", 2, "c"])
     end
   end

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -10,6 +10,55 @@ unless LogStash::Environment.const_defined?(:LOGSTASH_HOME)
   LogStash::Environment::LOGSTASH_HOME = File.expand_path("../../../", __FILE__)
 end
 
+
+describe LogStash::Filters::Mutate do
+
+  let(:config) { {} }
+  subject      { LogStash::Filters::Mutate.new(config) }
+
+  let(:attrs) { { } }
+  let(:event) { LogStash::Event.new(attrs) }
+
+  before(:each) do
+    subject.register
+  end
+
+  context "when doing uppercase of an array" do
+
+    let(:config) do
+      { "uppercase" => ["array_of"] }
+    end
+
+    let(:attrs) { { "array_of" => ["a", 2, "C"] } }
+
+    it "should uppercase not raise an error" do
+      expect { subject.filter(event) }.not_to raise_error
+    end
+
+    it "should convert only string elements" do
+      expect(event["array_of"]).to eq(["A", 2, "C"])
+    end
+  end
+
+  context "when doing lowercase of an array" do
+
+    let(:config) do
+      { "lowercase" => ["array_of"] }
+    end
+
+    let(:attrs) { { "array_of" => ["a", 2, "C"] } }
+
+    it "should uppercase all string elements" do
+      expect { subject.filter(event) }.not_to raise_error
+    end
+
+    it "should convert only string elements" do
+      expect(event["array_of"]).to eq(["a", 2, "c"])
+    end
+  end
+
+end
+
 describe LogStash::Filters::Mutate do
 
   context "config validation" do


### PR DESCRIPTION
Hi,
  this PR, supersede #4 including test and improving it by non removing not string object during the mutation.

This pr fix the issue descrived in #4 and in https://github.com/elastic/logstash/pull/2091