### PR TITLE
Add test for the strip notation

### DIFF
--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -12,6 +12,49 @@ end
 
 describe LogStash::Filters::Mutate do
 
+  let(:config) { {} }
+  subject      { LogStash::Filters::Mutate.new(config) }
+
+  let(:attrs) { { } }
+  let(:event) { LogStash::Event.new(attrs) }
+
+  before(:each) do
+    subject.register
+  end
+
+  describe "#strip" do
+
+    let(:config) do
+      { "strip" => ["path"] }
+    end
+
+    let(:attrs) { { "path" => " /store.php " } }
+
+    it "should cleam trailing spaces" do
+      subject.filter(event)
+      expect(event["path"]).to eq("/store.php")
+    end
+
+    context "when converting multiple attributed at once" do
+
+      let(:config) do
+        { "strip" => ["foo", "bar"] }
+      end
+
+      let(:attrs) { { "foo" => " /bar.php ", "bar" => " foo" } }
+
+      it "should cleam trailing spaces" do
+        subject.filter(event)
+        expect(event["foo"]).to eq("/bar.php")
+        expect(event["bar"]).to eq("foo")
+      end
+    end
+  end
+
+end
+
+describe LogStash::Filters::Mutate do
+
   context "config validation" do
    describe "invalid convert type should raise a configuration error" do
       config <<-CONFIG


### PR DESCRIPTION
As there were no test for the ```strip``` method I added a few here while validating #35.

This test avoid  using the old sample notation helpers in favor of a more rspec friendly notation. This notation is amined to be slowly introduced.