### PR TITLE
Fix of convert hash ignoring

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -59,7 +59,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
 
   # Convert a field's value to a different type, like turning a string to an
   # integer. If the field value is an array, all members will be converted.
-  # If the field is a hash, no action will be taken.
+  # If the field is a hash, all values of hash will be converted.
   #
   # If the conversion type is `boolean`, the acceptable values are:
   #
@@ -266,9 +266,13 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       if original.nil?
         next
       elsif original.is_a?(Hash)
-        @logger.debug("I don't know how to type convert a hash, skipping",
-                      :field => field, :value => original)
-        next
+        #@logger.debug("I don't know how to type convert a hash, skipping",
+        #              :field => field, :value => original)
+        #next
+        value = original
+        original.each do |hfield, hvalue|
+          value[hfield] = converter.call(hvalue)
+        end
       elsif original.is_a?(Array)
         value = original.map { |v| converter.call(v) }
       else


### PR DESCRIPTION
In convert mutating:
If the field is a hash, all values of hash will be converted.