### PR TITLE
Docs: Use backtick notation for %{varname} references

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -33,7 +33,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   # filters.
   config :remove, :validate => :array, :deprecated => true
 
-  # Replace a field with a new value. The new value can include %{foo} strings
+  # Replace a field with a new value. The new value can include `%{foo}` strings
   # to help you build a new value from other parts of the event.
   #
   # Example:


### PR DESCRIPTION
This should fix a documentation generation bug where a line is omitted because a `%{varname}` reference isn't surrounded by backticks. I haven't been able to verify the correction case since `rake docs:generate-docs` won't work for me (see https://discuss.elastic.co/t/missing-logstash-home-when-running-rake-docs-generate-docs/35949 — help would be appreciated).

@logstash-plugins/logstash-core, please review.