### PR TITLE
do not assume event field values as mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.3
+ - Code cleanups and fix field assignments
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -428,12 +428,17 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
           next
         end
 
+        # No need to test the other
         if dest_field_value.is_a?(Hash)
-          # No need to test the other
-          event[dest_field].update(added_field_value)
+          # do not use event[dest_field].update because the returned object from event[dest_field]
+          # can/will be a copy of the actual event data and directly updating it will not update
+          # the Event internal data. The updated value must be reassigned in the Event.
+          event[dest_field] = dest_field_value.update(added_field_value)
         else
-          event[dest_field] = Array(dest_field_value)
-          event[dest_field].concat(Array(added_field_value))
+          # do not use event[dest_field].concat because the returned object from event[dest_field]
+          # can/will be a copy of the actual event data and directly updating it will not update
+          # the Event internal data. The updated value must be reassigned in the Event.
+          event[dest_field] = Array(dest_field_value).concat(Array(added_field_value))
         end
       end
     end

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The mutate filter allows you to perform general mutations on fields. You can rename, remove, replace, and modify fields in your events."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
this PR build on top of #59 

- fix event mutability asumption.

relates to elastic/logstash#4264 and elastic/logstash#4191
requires elastic/logstash#4279 to pass specs under Java Event