### PR TITLE
Docs: Use backtick notation for %{fieldname} references

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -33,7 +33,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   # filters.
   config :remove, :validate => :array, :deprecated => true
 
-  # Replace a field with a new value. The new value can include %{foo} strings
+  # Replace a field with a new value. The new value can include `%{foo}` strings
   # to help you build a new value from other parts of the event.
   #
   # Example:


### PR DESCRIPTION
Apart from being consistent with the rest of the Logstash documentation, this should make the asciidoc generator happier so it won't skip the line with the non-backticked %{fieldname} reference when emitting the asciidoc file. This fixes #41.

I've tried to verify that this micropatch actually fixes the asciidoc rendering problem but I'm blocked by https://discuss.elastic.co/t/missing-logstash-home-when-running-rake-docs-generate-docs/35949.