### PR TITLE
Fixed undefined eventget method error

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -366,7 +366,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
 
   def split(event)
     @split.each do |field, separator|
-      value = eventget(field)
+      value = event.get(field)
       if value.is_a?(String)
         event.set(field, value.split(separator))
       else


### PR DESCRIPTION
Just added the missing point between the *event* object and the *get* method

