### PR TITLE
Elaborate on backslash escaping in gsub.

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -72,7 +72,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   # This configuration takes an array consisting of 3 elements per
   # field/substitution.
   #
-  # Be aware of escaping any backslash in the config file.
+  # Be aware of escaping any literal backslash in the config file.
+  # However, use a single backslash for predefined character classes like \d
+  # as well as for backreferences to capture groups like \1.
   #
   # Example:
   # [source,ruby]
@@ -81,6 +83,8 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   #         gsub => [
   #           # replace all forward slashes with underscore
   #           "fieldname", "/", "_",
+  #           # left-pad with a zero if it is a single digit
+  #           "numstr", "^(\d)$", "0\1",
   #           # replace backslashes, question marks, hashes, and minuses
   #           # with a dot "."
   #           "fieldname2", "[\\?#-]", "."


### PR DESCRIPTION
In our experiments with the gsub mutate filter it turned out that the documentation is a little bit misleading with respect to backslashes: escaping any backslash would deprive some regular expressions of their magic. Apart from that, an example that illustrates backreferences might help some users.

Please review this pull request and decide if you are willing to accept it.
