### PR TITLE
Wrong format used in the configuration file

### DIFF
--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -232,7 +232,7 @@ describe LogStash::Filters::Mutate do
       config <<-CONFIG
         filter {
           mutate {
-            convert => [ "message", "int"] //should be integer
+            convert => [ "message", "int"] #should be integer
           }
         }
       CONFIG


### PR DESCRIPTION
Replace `//` with `#` to express a comment in the configuration file

Fixes: #96
