### PR TITLE
use the new pipeline helper from devutils

### DIFF
--- a/spec/filters/integration/multi_stage_spec.rb
+++ b/spec/filters/integration/multi_stage_spec.rb
@@ -10,7 +10,10 @@ unless LogStash::Environment.const_defined?(:LOGSTASH_HOME)
 end
 
 describe LogStash::Filters::Mutate do
-  let(:pipeline) { LogStash::Pipeline.new(config) }
+  let(:pipeline) do
+    new_pipeline_from_string(config)
+  end
+
   let(:events) do
     arr = event.is_a?(Array) ? event : [event]
     arr.map do |evt|


### PR DESCRIPTION
We have changed method signature in master from 5.x, this refactor the
test to use the new helper in devutils that will use the right interface.