### PR TITLE
Clarify that arrays of strings also work in gsub operations

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -100,8 +100,9 @@ Example:
   * Value type is <<array,array>>
   * There is no default value for this setting.
 
-Convert a string field by applying a regular expression and a replacement.
-If the field is not a string, no action will be taken.
+Match a regular expression against a field value and replace all matches
+with a replacement string. Only fields that are strings or arrays of
+strings are supported. For other kinds of fields no action will be taken.
 
 This configuration takes an array consisting of 3 elements per
 field/substitution.

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -66,8 +66,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   #     }
   config :convert, :validate => :hash
 
-  # Convert a string field by applying a regular expression and a replacement.
-  # If the field is not a string, no action will be taken.
+  # Match a regular expression against a field value and replace all matches
+  # with another string. Only fields that are strings or arrays of strings are
+  # supported. For other kinds of fields no action will be taken.
   #
   # This configuration takes an array consisting of 3 elements per
   # field/substitution.
@@ -311,7 +312,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
           if v.is_a?(String)
             gsub_dynamic_fields(event, v, needle, replacement)
           else
-            @logger.warn("gsub mutation is only applicable for Strings, skipping", :field => field, :value => v)
+            @logger.warn("gsub mutation is only applicable for strings and arrays of strings, skipping", :field => field, :value => v)
             v
           end
         end
@@ -319,7 +320,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       when String
         event.set(field, gsub_dynamic_fields(event, value, needle, replacement))
       else
-        @logger.debug? && @logger.debug("gsub mutation is only applicable for Strings, skipping", :field => field, :value => event.get(field))
+        @logger.debug? && @logger.debug("gsub mutation is only applicable for strings and arrays of strings, skipping", :field => field, :value => event.get(field))
       end
     end
   end


### PR DESCRIPTION
Both the documentation and the log messages indicated that only string fields worked with gsub while in fact arrays of strings were processed too.