### PR TITLE
convert: handle non-string inputs gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.2
+ - Fix: when converting to `float` and `float_eu`, explicitly support same range of inputs as their integer counterparts; eliminates a regression introduced in 3.3.1 in which support for non-string inputs was inadvertently removed.
+
 ## 3.3.1
  - Fix: Number strings using a **decimal comma** (e.g. 1,23), added convert support to specify integer_eu and float_eu.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -62,25 +62,27 @@ Convert a field's value to a different type, like turning a string to an
 integer. If the field value is an array, all members will be converted.
 If the field is a hash no action will be taken.
 
-If the conversion type is `boolean`, the acceptable values are:
+Valid conversion targets, and their expected behaviour with different inputs are:
 
-* **True:** `true`, `t`, `yes`, `y`, and `1`
-* **False:** `false`, `f`, `no`, `n`, and `0`
-
-If a value other than these is provided, it will pass straight through
-and log a warning message.
-
-If the conversion type is `integer` and the value is a boolean, it will be converted as:
-* **True:**  `1`
-* **False:** `0`
-
-If you have numeric strings that have decimal commas (Europe and ex-colonies)
-e.g. "1.234,56" or "2.340", by using conversion targets of integer_eu or float_eu
-the convert function will treat "." as a group separator and "," as a decimal separator.
-
-Conversion targets of integer or float will now correctly handle "," as a group separator.
-
-Valid conversion targets are: integer, float, integer_eu, float_eu, string, and boolean.
+ * `integer`:
+   - strings are parsed; comma-separators are supported (e.g., the string `"1,000"` produces an integer with value of one thousand); when strings have decimal parts, they are _truncated_.
+   - floats and decimals are _truncated_ (e.g., `3.99` becomes `3`, `-2.7` becomes `-2`)
+   - boolean true and boolean false are converted to `1` and `0` respectively
+ * `integer_eu`:
+   - same as `integer`, except string values support dot-separators and comma-decimals (e.g., `"1.000"` produces an integer with value of one thousand)
+ * `float`:
+   - integers are converted to floats
+   - strings are parsed; comma-separators and dot-decimals are supported (e.g., `"1,000.5"` produces an integer with value of one thousand and one half)
+   - boolean true and boolean false are converted to `1.0` and `0.0` respectively
+ * `float_eu`:
+   - same as `float`, except string values support dot-separators and comma-decimals (e.g., `"1.000,5"` produces an integer with value of one thousand and one half)
+ * `string`:
+   - all values are stringified and encoded with UTF-8
+ * `boolean`:
+   - strings `"true"`, `"t"`, `"yes"`, `"y"`, and `"1"` are converted to boolean `true`
+   - strings `"false"`, `"f"`, `"no"`, `"n"`, and `"0"` are converted to boolean `false`
+   - empty strings are converted to boolean `false`
+   - all other values pass straight through without conversion and log a warning message
 
 This plugin can convert multiple fields in the same document, see the example below.
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -341,22 +341,29 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   end
 
   def convert_float(value)
-    value.tr(",", "").to_f
+    return 1.0 if value == true
+    return 0.0 if value == false
+    value = value.delete(",") if value.kind_of?(String)
+    value.to_f
   end
 
   def convert_integer_eu(value)
-    return 1 if value == true
-    return 0 if value == false
-    cnv_replace_eu(value).to_i
+    us_value = cnv_replace_eu(value)
+    convert_integer(us_value)
   end
 
   def convert_float_eu(value)
-    cnv_replace_eu(value).to_f
+    us_value = cnv_replace_eu(value)
+    convert_float(us_value)
   end
 
+  # When given a String, returns a new String whose contents have been converted from
+  # EU-style comma-decimals and dot-separators to US-style dot-decimals and comma-separators.
+  #
+  # For all other values, returns value unmodified.
   def cnv_replace_eu(value)
     return value if !value.is_a?(String)
-    value.tr(".", "").tr(",", ".")
+    value.tr(",.", ".,")
   end
 
   def gsub(event)

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.3.1'
+  s.version         = '3.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -415,6 +415,152 @@ describe LogStash::Filters::Mutate do
     end
   end
 
+  describe "convert to float" do
+
+    config <<-CONFIG
+      filter {
+        mutate {
+          convert => {
+            "field" => "float"
+          }
+        }
+      }
+    CONFIG
+
+    context 'when field is a string with no separator and dot decimal' do
+      sample({'field' => '3141.5926'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.5926)
+      end
+    end
+
+    context 'when field is a string with a comma separator and dot decimal' do
+      sample({'field' => '3,141.5926'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.5926)
+      end
+    end
+
+    context 'when field is a string comma separator and no decimal' do
+      sample({'field' => '3,141'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.0)
+      end
+    end
+
+    context 'when field is a string no separator and no decimal' do
+      sample({'field' => '3141'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.0)
+      end
+    end
+
+    context 'when field is a float' do
+      sample({'field' => 3.1415926}) do
+        expect(subject.get('field')).to be_within(0.000001).of(3.1415926)
+      end
+    end
+
+    context 'when field is an integer' do
+      sample({'field' => 3}) do
+        expect(subject.get('field')).to be_within(0.000001).of(3)
+      end
+    end
+
+    context 'when field is the true value' do
+      sample('field' => true) do
+        expect(subject.get('field')).to eq(1.0)
+      end
+    end
+
+    context 'when field is the false value' do
+      sample('field' => false) do
+        expect(subject.get('field')).to eq(0.0)
+      end
+    end
+
+    context 'when field is nil' do
+      sample('field' => nil) do
+        expect(subject.get('field')).to be_nil
+      end
+    end
+
+    context 'when field is not set' do
+      sample('field' => nil) do
+        expect(subject.get('field')).to be_nil
+      end
+    end
+  end
+
+
+  describe "convert to float_eu" do
+    config <<-CONFIG
+      filter {
+        mutate {
+          convert => {
+            "field" => "float_eu"
+          }
+        }
+      }
+    CONFIG
+
+    context 'when field is a string with no separator and comma decimal' do
+      sample({'field' => '3141,5926'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.5926)
+      end
+    end
+
+    context 'when field is a string with a dot separator and comma decimal' do
+      sample({'field' => '3.141,5926'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.5926)
+      end
+    end
+
+    context 'when field is a string dot separator and no decimal' do
+      sample({'field' => '3.141'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.0)
+      end
+    end
+
+    context 'when field is a string no separator and no decimal' do
+      sample({'field' => '3141'}) do
+        expect(subject.get('field')).to be_within(0.0001).of(3141.0)
+      end
+    end
+
+    context 'when field is a float' do
+      sample({'field' => 3.1415926}) do
+        expect(subject.get('field')).to be_within(0.000001).of(3.1415926)
+      end
+    end
+
+    context 'when field is an integer' do
+      sample({'field' => 3}) do
+        expect(subject.get('field')).to be_within(0.000001).of(3)
+      end
+    end
+
+    context 'when field is the true value' do
+      sample('field' => true) do
+        expect(subject.get('field')).to eq(1.0)
+      end
+    end
+
+    context 'when field is the false value' do
+      sample('field' => false) do
+        expect(subject.get('field')).to eq(0.0)
+      end
+    end
+
+    context 'when field is nil' do
+      sample('field' => nil) do
+        expect(subject.get('field')).to be_nil
+      end
+    end
+
+    context 'when field is not set' do
+      sample('field' => nil) do
+        expect(subject.get('field')).to be_nil
+      end
+    end
+  end
+
   describe "gsub on a String" do
     config '
       filter {


### PR DESCRIPTION
 - convert literal-true and literal-false to 1.0 and 0.0 respectively
 - strip commas only if value is a string
 - share implementation details with convert_float_eu

Fixes: logstash-plugins/logstash-filter-mutate#120
Supersedes: logstash-plugins/logstash-filter-mutate#121
