### PR TITLE
Adding ability to directly convert from integer and float to boolean

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -79,10 +79,15 @@ Valid conversion targets, and their expected behaviour with different inputs are
  * `string`:
    - all values are stringified and encoded with UTF-8
  * `boolean`:
-   - strings `"true"`, `"t"`, `"yes"`, `"y"`, and `"1"` are converted to boolean `true`
-   - strings `"false"`, `"f"`, `"no"`, `"n"`, and `"0"` are converted to boolean `false`
+   - integer 0 is converted to boolean `false`
+   - integer 1 is converted to boolean `true`
+   - float 0.0 is converted to boolean `false`
+   - float 1.0 is converted to boolean `true`
+   - strings `"true"`, `"t"`, `"yes"`, `"y"`, `"1"`and `"1.0"` are converted to boolean `true`
+   - strings `"false"`, `"f"`, `"no"`, `"n"`, `"0"` and `"0.0"` are converted to boolean `false`
    - empty strings are converted to boolean `false`
    - all other values pass straight through without conversion and log a warning message
+   - for arrays each value gets processed separately using rules above
 
 This plugin can convert multiple fields in the same document, see the example below.
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -207,8 +207,8 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   #     }
   config :copy, :validate => :hash
 
-  TRUE_REGEX = (/^(true|t|yes|y|1)$/i).freeze
-  FALSE_REGEX = (/^(false|f|no|n|0)$/i).freeze
+  TRUE_REGEX = (/^(true|t|yes|y|1|1.0)$/i).freeze
+  FALSE_REGEX = (/^(false|f|no|n|0|0.0)$/i).freeze
   CONVERT_PREFIX = "convert_".freeze
 
   def register
@@ -327,6 +327,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   end
 
   def convert_boolean(value)
+    value = value.to_s
     return true if value =~ TRUE_REGEX
     return false if value.empty? || value =~ FALSE_REGEX
     @logger.warn("Failed to convert #{value} into boolean.")

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -327,9 +327,8 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   end
 
   def convert_boolean(value)
-    value = value.to_s
-    return true if value =~ TRUE_REGEX
-    return false if value.empty? || value =~ FALSE_REGEX
+    return true if value.to_s =~ TRUE_REGEX
+    return false if value.to_s.empty? || value.to_s =~ FALSE_REGEX
     @logger.warn("Failed to convert #{value} into boolean.")
     value
   end

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -393,6 +393,8 @@ describe LogStash::Filters::Mutate do
           convert => { "float_negative"     => "boolean" }
           convert => { "float_wrong"        => "boolean" }
           convert => { "float_wrong2"       => "boolean" }
+          convert => { "array"              => "boolean" }
+          convert => { "hash"               => "boolean" }
         }
       }
     CONFIG
@@ -416,7 +418,9 @@ describe LogStash::Filters::Mutate do
       "float_false"     => 0.0,
       "float_negative"  => -1.0,
       "float_wrong"     => 1.0123,
-      "float_wrong2"    => 0.01
+      "float_wrong2"    => 0.01,
+      "array"           => [ "1", "0", 0,1,2],
+      "hash"            => { "a" => 0 }
     }
     sample event do
       expect(subject.get("true_field")      ).to eq(true)
@@ -432,13 +436,15 @@ describe LogStash::Filters::Mutate do
       expect(subject.get("wrong_field")     ).to eq("none of the above")
       expect(subject.get("integer_false")   ).to eq(false)
       expect(subject.get("integer_true")    ).to eq(true)
-      expect(subject.get("integer_negative")).to eq("-1")
-      expect(subject.get("integer_wrong")   ).to eq("2")
+      expect(subject.get("integer_negative")).to eq(-1)
+      expect(subject.get("integer_wrong")   ).to eq(2)
       expect(subject.get("float_true")      ).to eq(true)
       expect(subject.get("float_false")     ).to eq(false)
-      expect(subject.get("float_negative")  ).to eq("-1.0")
-      expect(subject.get("float_wrong")     ).to eq("1.0123")
-      expect(subject.get("float_wrong2")    ).to eq("0.01")
+      expect(subject.get("float_negative")  ).to eq(-1.0)
+      expect(subject.get("float_wrong")     ).to eq(1.0123)
+      expect(subject.get("float_wrong2")    ).to eq(0.01)
+      expect(subject.get("array")           ).to eq([true, false, false, true,2])
+      expect(subject.get("hash")            ).to eq({ "a" => 0 })
     end
   end
 
@@ -515,7 +521,6 @@ describe LogStash::Filters::Mutate do
     end
   end
   
-
 
   describe "convert to float_eu" do
     config <<-CONFIG

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -373,45 +373,72 @@ describe LogStash::Filters::Mutate do
     config <<-CONFIG
       filter {
         mutate {
-          convert => { "true_field"  => "boolean" }
-          convert => { "false_field" => "boolean" }
-          convert => { "true_upper"  => "boolean" }
-          convert => { "false_upper" => "boolean" }
-          convert => { "true_one"    => "boolean" }
-          convert => { "false_zero"  => "boolean" }
-          convert => { "true_yes"    => "boolean" }
-          convert => { "false_no"    => "boolean" }
-          convert => { "true_y"      => "boolean" }
-          convert => { "false_n"     => "boolean" }
-          convert => { "wrong_field" => "boolean" }
+          convert => { "true_field"         => "boolean" }
+          convert => { "false_field"        => "boolean" }
+          convert => { "true_upper"         => "boolean" }
+          convert => { "false_upper"        => "boolean" }
+          convert => { "true_one"           => "boolean" }
+          convert => { "false_zero"         => "boolean" }
+          convert => { "true_yes"           => "boolean" }
+          convert => { "false_no"           => "boolean" }
+          convert => { "true_y"             => "boolean" }
+          convert => { "false_n"            => "boolean" }
+          convert => { "wrong_field"        => "boolean" }
+          convert => { "integer_false"      => "boolean" }
+          convert => { "integer_true"       => "boolean" }
+          convert => { "integer_negative"   => "boolean" }
+          convert => { "integer_wrong"      => "boolean" }
+          convert => { "float_true"         => "boolean" }
+          convert => { "float_false"        => "boolean" }
+          convert => { "float_negative"     => "boolean" }
+          convert => { "float_wrong"        => "boolean" }
+          convert => { "float_wrong2"       => "boolean" }
         }
       }
     CONFIG
     event = {
-      "true_field"  => "true",
-      "false_field" => "false",
-      "true_upper"  => "True",
-      "false_upper" => "False",
-      "true_one"    => "1",
-      "false_zero"  => "0",
-      "true_yes"    => "yes",
-      "false_no"    => "no",
-      "true_y"      => "Y",
-      "false_n"     => "N",
-      "wrong_field" => "none of the above"
+      "true_field"      => "true",
+      "false_field"     => "false",
+      "true_upper"      => "True",
+      "false_upper"     => "False",
+      "true_one"        => "1",
+      "false_zero"      => "0",
+      "true_yes"        => "yes",
+      "false_no"        => "no",
+      "true_y"          => "Y",
+      "false_n"         => "N",
+      "wrong_field"     => "none of the above",
+      "integer_false"   => 0,
+      "integer_true"    => 1,
+      "integer_negative"=> -1,
+      "integer_wrong"   => 2,
+      "float_true"      => 1.0,
+      "float_false"     => 0.0,
+      "float_negative"  => -1.0,
+      "float_wrong"     => 1.0123,
+      "float_wrong2"    => 0.01
     }
     sample event do
-      expect(subject.get("true_field") ).to eq(true)
-      expect(subject.get("false_field")).to eq(false)
-      expect(subject.get("true_upper") ).to eq(true)
-      expect(subject.get("false_upper")).to eq(false)
-      expect(subject.get("true_one")   ).to eq(true)
-      expect(subject.get("false_zero") ).to eq(false)
-      expect(subject.get("true_yes")   ).to eq(true)
-      expect(subject.get("false_no")   ).to eq(false)
-      expect(subject.get("true_y")     ).to eq(true)
-      expect(subject.get("false_n")    ).to eq(false)
-      expect(subject.get("wrong_field")).to eq("none of the above")
+      expect(subject.get("true_field")      ).to eq(true)
+      expect(subject.get("false_field")     ).to eq(false)
+      expect(subject.get("true_upper")      ).to eq(true)
+      expect(subject.get("false_upper")     ).to eq(false)
+      expect(subject.get("true_one")        ).to eq(true)
+      expect(subject.get("false_zero")      ).to eq(false)
+      expect(subject.get("true_yes")        ).to eq(true)
+      expect(subject.get("false_no")        ).to eq(false)
+      expect(subject.get("true_y")          ).to eq(true)
+      expect(subject.get("false_n")         ).to eq(false)
+      expect(subject.get("wrong_field")     ).to eq("none of the above")
+      expect(subject.get("integer_false")   ).to eq(false)
+      expect(subject.get("integer_true")    ).to eq(true)
+      expect(subject.get("integer_negative")).to eq("-1")
+      expect(subject.get("integer_wrong")   ).to eq("2")
+      expect(subject.get("float_true")      ).to eq(true)
+      expect(subject.get("float_false")     ).to eq(false)
+      expect(subject.get("float_negative")  ).to eq("-1.0")
+      expect(subject.get("float_wrong")     ).to eq("1.0123")
+      expect(subject.get("float_wrong2")    ).to eq("0.01")
     end
   end
 
@@ -487,6 +514,7 @@ describe LogStash::Filters::Mutate do
       end
     end
   end
+  
 
 
   describe "convert to float_eu" do


### PR DESCRIPTION
[#73](https://github.com/logstash-plugins/logstash-filter-mutate/issues/73)
[#47](https://github.com/logstash-plugins/logstash-filter-mutate/issues/47)

It was not possible to convert from int or float directly to boolean.
After those changes initial value still remains untouched.
Added few more tests and confirmed that behaviour for hashes didn't change.
In case of arrays - now arrays containing integers/floats can be converted to boolean arrays