### PR TITLE
Omitempty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+ - feature: Added 'omitempty' feature to remove fields with default or null values
+
 ## 3.4.0
  - Added ability to directly convert from integer and float to boolean [#127](https://github.com/logstash-plugins/logstash-filter-mutate/pull/127)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.4.1
+## 3.5.1
  - feature: Added 'omitempty' feature to remove fields with default or null values
 
 ## 3.4.0

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@ Contributors:
 * Tal Levy (talevy)
 * piavlo
 * Abdul Haseeb Hussain (AbdulHaseebHussain)
+* Gregory Ferreux (gferreux)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -207,6 +207,17 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   #     }
   config :copy, :validate => :hash
 
+  # Omit a variable if it as a default value.
+  #
+  # Example:
+  # [source,ruby]
+  #     filter {
+  #       mutate {
+  #         omitempty => [ "fieldname" ]
+  #       }
+  #     }
+  config :omitempty, :validate => :array
+
   TRUE_REGEX = (/^(true|t|yes|y|1|1.0)$/i).freeze
   FALSE_REGEX = (/^(false|f|no|n|0|0.0)$/i).freeze
   CONVERT_PREFIX = "convert_".freeze
@@ -260,6 +271,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     join(event) if @join
     merge(event) if @merge
     copy(event) if @copy
+    omitempty(event) if @omitempty
 
     filter_matched(event)
   end
@@ -463,6 +475,26 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
         original
       end
       event.set(field, result)
+    end
+  end
+
+  def omitempty(event)
+    @omitempty.each do |field|
+      original = event.get(field)
+      if original.nil?
+        event.remove(field)
+        next
+      end
+      result = case original
+               when String, Array, Hash
+                 original.empty? ? nil : original
+               when Integer
+                 original == 0 ? nil : original
+               else
+                 @logger.debug? && @logger.debug("Can't omitempty something that isn't a string,array,hash,integer", :field => field, :value => original)
+                 original
+               end
+      event.remove(field) if result.nil?
     end
   end
 

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.4.0'
+  s.version         = '3.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -1038,4 +1038,45 @@ describe LogStash::Filters::Mutate do
     end
   end
 
+  describe "omitempty" do
+
+    config <<-CONFIG
+      filter {
+        mutate {
+          omitempty => ["field"]
+        }
+      }
+    CONFIG
+
+    context 'when field is a string' do
+      sample({'field' => ''}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is an integer' do
+      sample({'field' => 0}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is an empty hash' do
+      sample({'field' => {}}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is an empty array' do
+      sample({'field' => []}) do
+        expect(subject).not_to include("field")
+      end
+    end
+
+    context 'when field is null' do
+      sample({'field' => nil}) do
+        expect(subject).not_to include("field")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Add an operation called 'omitempty' to remove fields with null or default values.
(works with string "", integer 0, array [], hashes {}, and null values)

````
filter {
  mutate {
    omitempty => ["field"]
  }
}
````
will remove field if field = "", 0, [], {} or null

useful with the logstash-codec-protobuf to remove fields present in the proto definition that have no values, aka "omitempty"in the JSON marshaller options

(new to ruby and logstash filters dev, so please fell free to point any bad or misplaced statement, thanks)
