### PR TITLE
Docs: Corrected syntax for accessing arrays created by split

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,7 +52,7 @@ Example:
 filter {
     mutate {
         split => ["hostname", "."]
-        add_field => { "shortHostname" => "%{hostname[0]}" }
+        add_field => { "shortHostname" => "%{[hostname][0]}" }
     }
 
     mutate {    


### PR DESCRIPTION
Corrected syntax for accessing arrays created by split.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
