### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,7 +52,7 @@ Example:
 filter {
     mutate {
         split => ["hostname", "."]
-        add_field => { "shortHostname" => "%{hostname[0]}" }
+        add_field => { "shortHostname" => "%{[hostname][0]}" }
     }
 
     mutate {    


### PR DESCRIPTION
The example provided in the docs results in the following 

[2019-11-15T15:48:57,062][WARN ][logstash.filters.mutate  ][main] Exception caught while applying mutate filter {:exception=>"Invalid FieldReference: hostname[0]"}
/Users/ravishankerre.kourla/work/elk/logstash/logstash-7.4.0/vendor/bundle/jruby/2.5.0/gems/awesome_print-1.7.0/lib/awesome_print/formatters/base_formatter.rb:31: warning: constant ::Fixnum is dep
Filter I used to test:
filter {
   mutate {
       split => ["hostname", "."]
       add_field => { "shortHostname" => "%{hostname[0]}" }
   }
}

This works with the following change
add_field => { "shortHostname" => "%{[hostname][0]}" }

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
