### PR TITLE
Corrected format example for split

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -51,7 +51,7 @@ Example:
 -----
 filter {
     mutate {
-        split => ["hostname", "."]
+        split => { "hostname" => "." }
         add_field => { "shortHostname" => "%{hostname[0]}" }
     }
 


### PR DESCRIPTION
In docs
```
       split => ["hostname", "."] 
```
to
```
        split => { "hostname" => "." }
```