### PR TITLE
Test: adapt for devutils 2.0 compatibility

### DIFF
--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_development_dependency "logstash-patterns-core"
   s.add_development_dependency "logstash-filter-grok"
+  s.add_development_dependency "logstash-codec-plain"
   s.add_development_dependency "logstash-devutils"
 end

--- a/spec/filters/integration/multi_stage_spec.rb
+++ b/spec/filters/integration/multi_stage_spec.rb
@@ -1,71 +1,43 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
-require "logstash/filters/mutate"
 
-# running mutate which depends on grok  outside a logstash package means
-# LOGSTASH_HOME will not be defined, so let's set it here
-# before requiring the grok filter
-unless LogStash::Environment.const_defined?(:LOGSTASH_HOME)
-  LogStash::Environment::LOGSTASH_HOME = File.expand_path("../../../", __FILE__)
+module LogStash::Environment
+  # running mutate which depends on grok  outside a logstash package means
+  # LOGSTASH_HOME will not be defined, so let's set it here
+  # before requiring the grok filter
+  unless self.const_defined?(:LOGSTASH_HOME)
+    LOGSTASH_HOME = File.expand_path("../../../", __FILE__)
+  end
+
+  # also :pattern_path method must exist (due grok filter)
+  unless self.method_defined?(:pattern_path)
+    def pattern_path(path)
+      ::File.join(LOGSTASH_HOME, "patterns", path)
+    end
+  end
 end
 
-describe LogStash::Filters::Mutate do
-  let(:pipeline) do
-    new_pipeline_from_string(config)
-  end
+describe 'LogStash::Filters::Mutate' do
 
-  let(:events) do
-    arr = event.is_a?(Array) ? event : [event]
-    arr.map do |evt|
-      LogStash::Event.new(evt.is_a?(String) ? LogStash::Json.load(evt) : evt)
-    end
-  end
-
-  let(:results) do
-    pipeline.instance_eval { @filters.each(&:register) }
-    results  = []
-    events.each do |evt|
-      # filter call the block on all filtered events, included new events added by the filter
-      pipeline.filter(evt) do |filtered_event|
-        results.push(filtered_event)
-      end
-    end
-    pipeline.flush_filters(:final => true) { |flushed_event| results << flushed_event }
-
-    results.select { |e| !e.cancelled? }
-  end
-
-  describe 'MUTATE-33: multi stage with json, grok and mutate, Case mutation' do
-    let(:event) do
-      "{\"message\":\"hello WORLD\",\"lower1\":\"PPQQRRSS\",\"lower2\":\"pppqqq\"}"
-    end
-
+  context 'MUTATE-33: multi stage with json, grok and mutate, Case mutation' do
     let(:config) do
       <<-CONFIG
-filter {
-    grok {
+    filter {
+      grok {
         match => { "message" => "(?:hello) %{WORD:bar}" }
         break_on_match => false
+      }
+      mutate {
+        lowercase => [ "bar", "lower1", "lower2" ]
+      }
     }
-    mutate {
-      lowercase => [ "bar", "lower1", "lower2" ]
-    }
-}
 CONFIG
     end
 
-    it 'change case of the target, bar value is lowercase' do
+    sample("message" => "hello WORLD", "lower1" => "PPQQRRSS", "lower2" => "pppqqq") do
       result = results.first
       expect(result.get("bar")).to eq('world')
-    end
-
-    it 'change case of the target, lower1 value is lowercase' do
-      result = results.first
       expect(result.get("lower1")).to eq("ppqqrrss")
-    end
-
-    it 'change case of the target, lower2 value is lowercase' do
-      result = results.first
       expect(result.get("lower2")).to eq("pppqqq")
     end
 

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -570,7 +570,7 @@ describe LogStash::Filters::Mutate do
       end
     end
   end
-  
+
 
   describe "convert to float_eu" do
     config <<-CONFIG
@@ -745,8 +745,8 @@ describe LogStash::Filters::Mutate do
     CONFIG
 
     sample("field_one" => "value", "x" => "one") do
-      reject { subject }.include?("field_one")
-      insist { subject }.include?("destination")
+      expect(subject).to_not include("field_one")
+      expect(subject).to include("destination")
     end
   end
 
@@ -760,8 +760,8 @@ describe LogStash::Filters::Mutate do
     CONFIG
 
     sample("field_one" => "value", "x" => "one") do
-      reject { subject }.include?("origin")
-      insist { subject }.include?("field_one")
+      expect(subject).to_not include("origin")
+      expect(subject).to include("field_one")
     end
   end
 

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -776,7 +776,7 @@ describe LogStash::Filters::Mutate do
 
     sample({ "foo" => { "bar" => "1000" } }) do
       expect(subject.get("[foo][bar]")).to eq 1000
-      expect(subject.get("[foo][bar]")).to be_a(Fixnum)
+      expect(subject.get("[foo][bar]")).to be_a(Integer)
     end
  end
 
@@ -791,7 +791,7 @@ describe LogStash::Filters::Mutate do
 
     sample({ "foo" => ["100", "200"] }) do
       expect(subject.get("[foo][0]")).to eq 100
-      expect(subject.get("[foo][0]")).to be_a(Fixnum)
+      expect(subject.get("[foo][0]")).to be_a(Integer)
     end
   end
 
@@ -812,15 +812,15 @@ describe LogStash::Filters::Mutate do
 
     sample({ "foo" => [false, true, "0", "1", "2"] }) do
       expect(subject.get("[foo][0]")).to eq 0
-      expect(subject.get("[foo][0]")).to be_a(Fixnum)
+      expect(subject.get("[foo][0]")).to be_a(Integer)
       expect(subject.get("[foo][1]")).to eq 1
-      expect(subject.get("[foo][1]")).to be_a(Fixnum)
+      expect(subject.get("[foo][1]")).to be_a(Integer)
       expect(subject.get("[foo][2]")).to eq 0
-      expect(subject.get("[foo][2]")).to be_a(Fixnum)
+      expect(subject.get("[foo][2]")).to be_a(Integer)
       expect(subject.get("[foo][3]")).to eq 1
-      expect(subject.get("[foo][3]")).to be_a(Fixnum)
+      expect(subject.get("[foo][3]")).to be_a(Integer)
       expect(subject.get("[foo][4]")).to eq 2
-      expect(subject.get("[foo][4]")).to be_a(Fixnum)
+      expect(subject.get("[foo][4]")).to be_a(Integer)
     end
   end
 
@@ -840,11 +840,11 @@ describe LogStash::Filters::Mutate do
 
       sample({ "foo" => ["1,000", "1,234,567.8", "123.4"] }) do
         expect(subject.get("[foo][0]")).to eq 1000
-        expect(subject.get("[foo][0]")).to be_a(Fixnum)
+        expect(subject.get("[foo][0]")).to be_a(Integer)
         expect(subject.get("[foo][1]")).to eq 1234567
-        expect(subject.get("[foo][1]")).to be_a(Fixnum)
+        expect(subject.get("[foo][1]")).to be_a(Integer)
         expect(subject.get("[foo][2]")).to eq 123
-        expect(subject.get("[foo][2]")).to be_a(Fixnum)
+        expect(subject.get("[foo][2]")).to be_a(Integer)
       end
     end
 
@@ -888,11 +888,11 @@ describe LogStash::Filters::Mutate do
 
       sample({ "foo" => ["1.000", "1.234.567,8", "123,4"] }) do
         expect(subject.get("[foo][0]")).to eq 1000
-        expect(subject.get("[foo][0]")).to be_a(Fixnum)
+        expect(subject.get("[foo][0]")).to be_a(Integer)
         expect(subject.get("[foo][1]")).to eq 1234567
-        expect(subject.get("[foo][1]")).to be_a(Fixnum)
+        expect(subject.get("[foo][1]")).to be_a(Integer)
         expect(subject.get("[foo][2]")).to eq 123
-        expect(subject.get("[foo][2]")).to be_a(Fixnum)
+        expect(subject.get("[foo][2]")).to be_a(Integer)
       end
     end
 


### PR DESCRIPTION
an integration-like spec needed a rewrite as it was relying on Ruby pipeline internals
*NOTE: the `sample` helper does ~ same and is also available on devutils 1.3.6 ...*