### PR TITLE
Case Conversions: Avoid mutating underlying Ruby String object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.5.1
+ - Fix: removed a minor optimization in case-conversion helpers that could result in a race condition in very rare and specific situations [#151](https://github.com/logstash-plugins/logstash-filter-mutate/pull/151)
+
+## 3.5.0
+ - Fix: eliminated possible pipeline crashes; when a failure occurs during the application of this mutate filter, the rest of
+the operations are now aborted and a configurable tag is added to the event [#136](https://github.com/logstash-plugins/logstash-filter-mutate/pull/136)
+
 ## 3.4.0
  - Added ability to directly convert from integer and float to boolean [#127](https://github.com/logstash-plugins/logstash-filter-mutate/pull/127)
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -424,8 +424,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
             (elem.is_a?(String) ? elem.upcase : elem)
           end
         when String
-          # nil means no change was made to the String
-          original.upcase! || original
+          original.upcase
         else
           @logger.debug? && @logger.debug("Can't uppercase something that isn't a string", :field => field, :value => original)
           original
@@ -445,7 +444,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
           (elem.is_a?(String) ? elem.downcase : elem)
         end
       when String
-        original.downcase! || original
+        original.downcase
       else
         @logger.debug? && @logger.debug("Can't lowercase something that isn't a string", :field => field, :value => original)
         original
@@ -465,7 +464,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
           (elem.is_a?(String) ? elem.capitalize : elem)
         end
       when String
-        original.capitalize! || original
+        original.capitalize
       else
         @logger.debug? && @logger.debug("Can't capitalize something that isn't a string", :field => field, :value => original)
         original

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.5.0'
+  s.version         = '3.5.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -399,10 +399,9 @@ describe LogStash::Filters::Mutate do
     }
 
     sample event do
-      # ATM, only the ASCII characters will case change
-      expect(subject.get("lowerme")).to eq [ "АБВГД\0mmm", "こにちわ", "xyzółć", "nÎcË gÛŸ"]
-      expect(subject.get("upperme")).to eq [ "аБвгд\0MMM", "こにちわ", "XYZółć", "NîCë Gûÿ"]
-      expect(subject.get("capitalizeme")).to eq [ "АБВГД\u0000mmm", "こにちわ", "Xyzółć", "NÎcË gÛŸ"]
+      expect(subject.get("lowerme")).to eq [ "абвгд\0mmm", "こにちわ", "xyzółć", "nîcë gûÿ"]
+      expect(subject.get("upperme")).to eq [ "АБВГД\0MMM", "こにちわ", "XYZÓŁĆ", "NÎCË GÛŸ"]
+      expect(subject.get("capitalizeme")).to eq [ "Абвгд\0mmm", "こにちわ", "Xyzółć", "Nîcë gûÿ"]
     end
   end
 

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -153,6 +153,21 @@ describe LogStash::Filters::Mutate do
         expect(event).not_to include("fake_field")
       end
     end
+    context "avoid mutating contents of field, as they may be shared" do
+      let(:original_value) { "oRiGiNaL vAlUe".freeze }
+      let(:shared_value) { original_value.dup }
+      let(:attrs) { {"field" => shared_value } }
+      let(:config) do
+        {
+          operation => "field"
+        }
+      end
+
+      it 'should not mutate the value' do
+        subject.filter(event)
+        expect(shared_value).to eq(original_value)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Because we cannot guarantee sole ownership of the underlying string object
attached to an event's field, mutating it is dangerous and can produce race
conditions when multiple operations in a pipeline mutate the same field in
different ways.

This patch choses instead to use non-destructive operations.

Using non-destructive operations incurs a cost overhead of a single ruby object
allocation and subsequent single ruby object dereference (which may or may not
make the original object eligible for Garbage Collection). This is very minimal
overhead compared to everything else that is happening in the pipeline and the
optimization is not worth the loss of safety.