### PR TITLE
fix i18n lookup of error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.2
+ - Fix: ensure that when an error occurs during registration, we use the correct i18n key to propagate the error message in a useful manner [#154](https://github.com/logstash-plugins/logstash-filter-mutate/pull/154)
+
 ## 3.5.1
  - Fix: removed a minor optimization in case-conversion helpers that could result in a race condition in very rare and specific situations [#151](https://github.com/logstash-plugins/logstash-filter-mutate/pull/151)
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -220,7 +220,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     @convert.nil? or @convert.each do |field, type|
       if !valid_conversions.include?(type)
         raise LogStash::ConfigurationError, I18n.t(
-          "logstash.agent.configuration.invalid_plugin_register",
+          "logstash.runner.configuration.invalid_plugin_register",
           :plugin => "filter",
           :type => "mutate",
           :error => "Invalid conversion type '#{type}', expected one of '#{valid_conversions.join(',')}'"
@@ -232,7 +232,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     @gsub.nil? or @gsub.each_slice(3) do |field, needle, replacement|
       if [field, needle, replacement].any? {|n| n.nil?}
         raise LogStash::ConfigurationError, I18n.t(
-          "logstash.agent.configuration.invalid_plugin_register",
+          "logstash.runner.configuration.invalid_plugin_register",
           :plugin => "filter",
           :type => "mutate",
           :error => "Invalid gsub configuration #{[field, needle, replacement]}. gsub requires 3 non-nil elements per config entry"

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.5.1'
+  s.version         = '3.5.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -321,7 +321,7 @@ describe LogStash::Filters::Mutate do
       CONFIG
 
       sample "not_really_important" do
-        expect {subject}.to raise_error LogStash::ConfigurationError
+        expect {subject}.to raise_error(LogStash::ConfigurationError, /Invalid conversion type/)
       end
     end
     describe "invalid gsub triad should raise a configuration error" do
@@ -334,7 +334,7 @@ describe LogStash::Filters::Mutate do
       CONFIG
 
       sample "not_really_important" do
-        expect {subject}.to raise_error LogStash::ConfigurationError
+        expect {subject}.to raise_error(LogStash::ConfigurationError, /Invalid gsub configuration/)
       end
     end
   end


### PR DESCRIPTION
Refines existing spec to ensure we get the error message we intend, and not
one indicating that we failed to look up the translation.
