### PR TITLE
In 'replace' documentation, mention 'add' behavior

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -280,7 +280,8 @@ Example:
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-Replace the value of a field with a new value. The new value can include `%{foo}` strings
+Replace the value of a field with a new value, or add the field if it
+doesn't already exist. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 Example:


### PR DESCRIPTION
The [current implementation of the `replace` method](https://github.com/logstash-plugins/logstash-filter-mutate/blob/9d691111049a10e45d83155497eb8a6778aa3f45/lib/logstash/filters/mutate.rb#L300-L304) uses `event.set()`, which adds the field if it doesn't already exist.  This PR adds that to the documentation, so filter authors know what to expect.