### PR TITLE
[DOC] Ruby float to Elasticsearch float might lead to lossy conversion

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -104,11 +104,9 @@ If the field is a hash no action will be taken.
 .Conversion insights
 [NOTE]
 ================================================================================
-The values are converted to Ruby data types.
-Be aware using `float` and `float_eu` converts the number in Ruby `Float`, 
-which is double-precision floating point representation.
-In order to not lose precision due to the conversion, you should
-us `double` in the Elasticsearch mappings.
+The values are converted using Ruby semantics.
+Be aware that using `float` and `float_eu` converts the value to a double-precision 64-bit IEEE 754 floating point decimal number.
+In order to maintain precision due to the conversion, you should use a `double` in the Elasticsearch mappings.
 ================================================================================
 
 Valid conversion targets, and their expected behaviour with different inputs are:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -101,6 +101,16 @@ Convert a field's value to a different type, like turning a string to an
 integer. If the field value is an array, all members will be converted.
 If the field is a hash no action will be taken.
 
+.Conversion insights
+[NOTE]
+================================================================================
+The values are converted to Ruby data types.
+Be aware using `float` and `float_eu` converts the number in Ruby `Float`, 
+which is double-precision floating point representation.
+In order to not lose precision due to the conversion, you should
+us `double` in the Elasticsearch mappings.
+================================================================================
+
 Valid conversion targets, and their expected behaviour with different inputs are:
 
  * `integer`:


### PR DESCRIPTION
[Floats in Ruby](https://ruby-doc.org/core-2.5.0/Float.html) are actually `double` in Elasticsearch (Java).

```
double this_is_double = 11000000000.0d;
float this_is_float = 11000000000.0f;
System.out.println(String.format("%.2f", this_is_double));
System.out.println(String.format("%.2f", this_is_float));
```

Results in:
```
11000000000.00
11000000512.00
```

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
