### PR TITLE
Clarify that `split` and `join` also support strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.7
+  - Clarify that `split` and `join` also support strings [#164](https://github.com/logstash-plugins/logstash-filter-mutate/pull/164)
+
 ## 3.5.6
  - [DOC] Added info on maintaining precision between Ruby float and Elasticsearch float [#158](https://github.com/logstash-plugins/logstash-filter-mutate/pull/158)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -200,7 +200,8 @@ Example:
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-Join an array with a separator character. Does nothing on non-array fields.
+Join an array with a separator character or string.
+Does nothing on non-array fields.
 
 Example:
 [source,ruby]
@@ -312,8 +313,8 @@ Example:
   * Value type is <<hash,hash>>
   * There is no default value for this setting.
 
-Split a field to an array using a separator character. Only works on string
-fields.
+Split a field to an array using a separator character or string.
+Only works on string fields.
 
 Example:
 [source,ruby]

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.5.6'
+  s.version         = '3.5.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
[`split` and `join` are implemented using the Ruby methods with the same name](https://github.com/logstash-plugins/logstash-filter-mutate/blob/05f748b91d5e0f156f99478604b22f9ec2929e4b/lib/logstash/filters/mutate.rb#L475=
).  Those Ruby methods support multi-character strings, so the Logstash filter does, too.