### PR TITLE
Fix the merge function of the mutate filter

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -508,9 +508,8 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     @merge.each do |dest_field, added_fields|
       # When multiple calls, added_field is an array
 
-      dest_field_value = event.get(dest_field)
-
       Array(added_fields).each do |added_field|
+        dest_field_value = event.get(dest_field)
         added_field_value = event.get(added_field)
 
         if dest_field_value.is_a?(Hash) ^ added_field_value.is_a?(Hash)


### PR DESCRIPTION
The dest_field_value was derived before the added fields were iterated upon. This caused the subsequent `event.set`'s, when iterating over multiple `added_field_value`'s, to set the `dest_field` based on the _initial_ `dest_field_value`. 

The logic should, instead, update the `dest_field_value` on each iteration of `added_field` so that it may continue to add to the `dest_field_value` instead of always only adding the last item in the list.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
