### PR TITLE
Fix merge multi field

### DIFF
--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -508,10 +508,9 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     @merge.each do |dest_field, added_fields|
       # When multiple calls, added_field is an array
 
-      dest_field_value = event.get(dest_field)
-
       Array(added_fields).each do |added_field|
         added_field_value = event.get(added_field)
+        dest_field_value = event.get(dest_field)
 
         if dest_field_value.is_a?(Hash) ^ added_field_value.is_a?(Hash)
           @logger.error("Not possible to merge an array and a hash: ", :dest_field => dest_field, :added_field => added_field )

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -1079,6 +1079,21 @@ describe LogStash::Filters::Mutate do
       expect(subject.get("foo")).to eq "bar"
     end
   end
+  
+  describe "merge multiple fields into string field" do
+    config '
+      filter {
+        mutate {
+          merge => [ "list", [ "foo", "spam" ] ]
+        }
+      }'
+
+    sample("foo" => "bar", "spam" => "ham", "list" => "baz") do
+      expect(subject.get("list")).to eq ["baz", "bar", "ham"]
+      expect(subject.get("foo")).to eq "bar"
+      expect(subject.get("spam")).to eq "ham"
+    end
+  end
 
   describe "coerce arrays fields with default values when null" do
     config '


### PR DESCRIPTION
Fix for merging an array of fields into the destination using the merge mutation.

I have included a test which produces the following failure prior to the fix:
```
LogStash::Filters::Mutate merge multiple fields into string field "{\"foo\":\"bar\",\"spam\":\"ham\",\"list\":\"baz\"}" processes events as specified
     Failure/Error: expect(subject.get("list")).to eq ["baz", "bar", "ham"]
     
       expected: ["baz", "bar", "ham"]
            got: ["baz", "ham"]
     
       (compared using ==)
     # ./spec/filters/mutate_spec.rb:1092:in `block in <main>'
```

Test passes after the fix.

Fixes #167