### PR TITLE
Fix "Can't modify frozen string" error when converting boolean to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.8
+  - Fix "Can't modify frozen string" error when converting boolean to `string` [#171](https://github.com/logstash-plugins/logstash-filter-mutate/pull/171) 
+  
 ## 3.5.7
   - Clarify that `split` and `join` also support strings [#164](https://github.com/logstash-plugins/logstash-filter-mutate/pull/164)
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -330,6 +330,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     # target encoding and only change if necessary, so calling
     # valid_encoding? is redundant
     # see https://twitter.com/jordansissel/status/444613207143903232
+    # use + since .to_s on nil/boolean returns a frozen string since ruby 2.7
     (+value.to_s).force_encoding(Encoding::UTF_8)
   end
 

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -330,7 +330,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
     # target encoding and only change if necessary, so calling
     # valid_encoding? is redundant
     # see https://twitter.com/jordansissel/status/444613207143903232
-    value.to_s.force_encoding(Encoding::UTF_8)
+    (+value.to_s).force_encoding(Encoding::UTF_8)
   end
 
   def convert_boolean(value)

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.5.7'
+  s.version         = '3.5.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -934,6 +934,26 @@ describe LogStash::Filters::Mutate do
     end
   end
 
+  describe "convert auto-frozen values to string" do
+    config <<-CONFIG
+      filter {
+        mutate {
+          convert => {
+            "true_field"  => "string"
+            "false_field" => "string"
+          }
+        }
+      }
+    CONFIG
+
+    sample({ "true_field" => true, "false_field" => false, "nil_field" => nil }) do
+      expect(subject.get("true_field")).to eq "true"
+      expect(subject.get("true_field")).to be_a(String)
+      expect(subject.get("false_field")).to eq "false"
+      expect(subject.get("false_field")).to be_a(String)
+    end
+  end
+
   #LOGSTASH-1529
   describe "gsub on a String with dynamic fields (%{}) in pattern" do
     config '

--- a/spec/filters/mutate_spec.rb
+++ b/spec/filters/mutate_spec.rb
@@ -946,7 +946,7 @@ describe LogStash::Filters::Mutate do
       }
     CONFIG
 
-    sample({ "true_field" => true, "false_field" => false, "nil_field" => nil }) do
+    sample({ "true_field" => true, "false_field" => false }) do
       expect(subject.get("true_field")).to eq "true"
       expect(subject.get("true_field")).to be_a(String)
       expect(subject.get("false_field")).to eq "false"


### PR DESCRIPTION
This PR fixes the "Can't modify frozen string" error when converting from boolean to `string` in Logstash 8.11.

---
Closes: https://github.com/logstash-plugins/logstash-filter-mutate/issues/170