### PR TITLE
Fix integer conversion precision loss on JRuby 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.0
+  - Add JRuby 10 support: fix integer conversion precision loss beyond 2^53 caused by `parse_signed_hex_str` routing all strings through `Float()` [#178](https://github.com/logstash-plugins/logstash-filter-mutate/pull/178)
+
 ## 3.5.9
   - Fix `convert` to covert hexadecimal float notation and scientific notation string to float and integer [#175](https://github.com/logstash-plugins/logstash-filter-mutate/pull/175)
   

--- a/lib/logstash/filters/mutate.rb
+++ b/lib/logstash/filters/mutate.rb
@@ -365,7 +365,7 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
       # scientific notation. BigDecimal() can't parse hex string
       return BigDecimal(value).to_i if value.include?("e")
       # maybe a float string
-      return value.to_i
+      return BigDecimal(value).to_i
     end
 
     Integer(value)
@@ -414,7 +414,10 @@ class LogStash::Filters::Mutate < LogStash::Filters::Base
   # @param value [String] the string to parse
   # @return [Float, nil] the signed float value if hex, or nil if not a hex string
   def parse_signed_hex_str(value)
-    return Float(value) if @support_signed_hex
+    if @support_signed_hex
+      return Float(value) if value.match?(/^[+-]?0x/i)
+      return nil
+    end
 
     if value.match?(/^[+-]?0x/i)
       sign = value.start_with?('-') ? -1 : 1

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-mutate'
-  s.version         = '3.5.9'
+  s.version         = '3.6.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Performs mutations on fields"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-mutate.gemspec
+++ b/logstash-filter-mutate.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "bigdecimal"
   s.add_development_dependency "logstash-patterns-core"
   s.add_development_dependency "logstash-filter-grok"
   s.add_development_dependency "logstash-codec-plain"


### PR DESCRIPTION
`parse_signed_hex_str` applied `Float()` to all strings when JRuby 10's `Float()` gained signed hex support. This truncated values beyond 2^53. Restrict the `Float()` to hex strings only.

Also use BigDecimal for float-string-to-integer conversion and declare bigdecimal as a runtime gem dependency for JRuby 10.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/


Closes: https://github.com/logstash-plugins/logstash-filter-mutate/issues/177